### PR TITLE
remove Web Access Control mention from spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@ of encrypted information among one or more entities.
           <p>
 The system is expected to specify one mandatory authorization scheme,
 but also allow other alternate authorization schemes. Examples of
-authorization schemes include OAuth2, Web Access Control, and
+authorization schemes include OAuth2 and
 [[ZCAP]]s (Authorization Capabilities).
           </p>
         </section>


### PR DESCRIPTION
based on today's call wherein Alan pointed out WAC may not afford for delegation (esp offline delegation)